### PR TITLE
Add pagination 'menu', implement next page of results functionality.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,15 @@
 </div>
 
 <div id="search-results" class="debug">
-	<p id="results-message">Total results: <span id="results-count"></span></p>
+	<div class="nav">
+		<p id="results-message">Total results: <span id="results-count"></span></p>
+		<div id="pagination-links">
+			<a href="#" class="previous-link"><button>Previous</button></a>
+			<p id="current-page-number">1</p>
+			<a href="#" class="next-link"><button>Next</button></a>
+		</div>
+	</div>
+	
 	<div id="search-results-list">
 
 	</div>

--- a/twitchery.css
+++ b/twitchery.css
@@ -25,5 +25,13 @@ html, body{
 	display: none;
 }
 
+#pagination-links{
+	float: right;
+}
+
+.inline-b{
+	display:inline-block;
+}
+
 
 

--- a/twitchery.js
+++ b/twitchery.js
@@ -34,8 +34,6 @@ document.addEventListener("DOMContentLoaded", function(){
 
 		    var queryResults = JSON.parse(xmlhttp.responseText)
 
-		    // var totalResultsCount = document.getElementById('results-count')
-		    // totalResultsCount.innerText = queryResults['_total']
 		    updateResults(queryResults['_total'])
 
 		    handlePagination(queryResults)
@@ -76,6 +74,14 @@ document.addEventListener("DOMContentLoaded", function(){
 	function handlePagination(queryResults){
 		if(queryResults["_total"] > 10){
 			console.log("generate " + Math.ceil(queryResults["_total"] / 10) + " pages")
+			if(queryResults["_links"]["next"]){
+			alert(queryResults["_links"]["next"])
+			var nextPageLink = document.getElementsByClassName("next-link")[0]
+			nextPageLink.setAttribute("href", queryResults["_links"]["next"])
+			}
+			if(queryResults["_links"]["prev"]){
+				alert(queryResults["_links"]["prev"])
+			}
 		}
 	}
 
@@ -127,6 +133,44 @@ document.addEventListener("DOMContentLoaded", function(){
 
 	function resetSearchBar(){
 		searchBar.value = ""
+	}
+
+	function navigateToPage(){
+		var xmlhttp;
+		if (window.XMLHttpRequest)
+		  {// code for IE7+, Firefox, Chrome, Opera, Safari
+		  xmlhttp=new XMLHttpRequest();
+		  }
+		else
+		  {// code for IE6, IE5
+		  xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
+		  }
+		xmlhttp.onreadystatechange=function()
+		  {
+		  if (xmlhttp.readyState==4 && xmlhttp.status==200)
+		    {
+
+		    var queryResults = JSON.parse(xmlhttp.responseText)
+
+		    updateResults(queryResults['_total'])
+
+		    handlePagination(queryResults)
+
+		    var streamResults = queryResults["streams"]
+		    streamResults.forEach(function(result){
+		    	searchResultsList.appendChild(createThumbnailImage(result))
+		    	searchResultsList.appendChild(addStreamName(result))
+		    	searchResultsList.appendChild(addViewersCount(result))
+		    	searchResultsList.appendChild(addStreamDescription(result))
+		    })
+		    }
+		  else if(xmlhttp.readyState==4 && xmlhttp.status==400){
+		  	updateResults()
+		  }
+
+		  }  
+		xmlhttp.open("GET", baseAPIUrl + searchQuery, true)
+		xmlhttp.send()
 	}
 
 })


### PR DESCRIPTION
Added a navbar for the search results section of the page. The navbar contains the total number of results found in addition to the newly added controls for going back and forth between the results pages if applicable. Only implemented the next results page functionality; it redirects to the actual API Route, will work on it to dynamically refresh the results section of the page before implementing the previous results page functionality.
