### PR TITLE
Dynamically change current page index upon hitting next/prev button.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 		<p id="results-message">Total results: <span id="results-count"></span></p>
 		<div id="pagination-links">
 			<a href="#" class="previous-link"><button>Previous</button></a>
-			<p id="current-page-number">1</p>
+			<p id="page-index"><span id="current-page-number">1</span> / <span id="total-num-pages">1</span></p>
 			<a href="#" class="next-link"><button>Next</button></a>
 		</div>
 	</div>

--- a/twitchery.js
+++ b/twitchery.js
@@ -10,7 +10,6 @@ document.addEventListener("DOMContentLoaded", function(){
 	var searchResultsList = document.getElementById('search-results-list')
 	var resultsCountText = document.getElementById('results-count')
 
-	//lesson learned: without the event.preventDefault(), the search bar would automatically clear its content and remove the dynamically appended content after being submitted
 	function returnSearchResults(event){
 		event.preventDefault()
 		resultsMessage.style.visibility = 'visible'
@@ -73,7 +72,20 @@ document.addEventListener("DOMContentLoaded", function(){
 
 	function handlePagination(queryResults){
 		if(queryResults["_total"] > 10){
-			console.log("generate " + Math.ceil(queryResults["_total"] / 10) + " pages")
+			//denominator in the current page/ total pages
+			// console.log("generate " + Math.ceil(queryResults["_total"] / 10) + " pages")
+			var currentPageNumber = document.getElementById("current-page-number")
+			var indexOfResultPageNumber = queryResults["_links"]["self"].indexOf("offset")
+
+			//identified bug - the api still provides a next link even if there are no streams returned from the next link
+			var resultPageNumber = parseInt(queryResults["_links"]["self"].substring(indexOfResultPageNumber + 7, indexOfResultPageNumber + 8)) + 1
+			currentPageNumber.innerText = resultPageNumber
+
+			var totalPageCount = document.getElementById("total-num-pages")
+			var indexOfLimitParam = queryResults["_links"]["self"].indexOf("limit")
+			var requestLimit = queryResults["_links"]["self"].substring(indexOfLimitParam + 6, indexOfLimitParam + 8)
+			totalPageCount.innerText = Math.ceil(queryResults["_total"] / requestLimit)
+
 			if(queryResults["_links"]["next"]){
 				var nextPageLink = document.getElementsByClassName("next-link")[0]
 				nextPageLink.setAttribute("href", queryResults["_links"]["next"])
@@ -173,7 +185,6 @@ document.addEventListener("DOMContentLoaded", function(){
 		  }
 
 		  }  
-		  alert(this.href)
 		xmlhttp.open("GET", this.href, true)
 		xmlhttp.send()
 	}


### PR DESCRIPTION
Used the XHR response object to retrieve the limit and offset parameter values which correspond to the number of results show per page and 'current set' of results. Modified the HTML to have two spans within a paragraph that shows the page index, where the first reveals the current page index, and the latter refers to the total number of pages. Also identified a potential bug with the API: the response still contains a 'next link' for the 'last set ' of results, which will redirect you to that route even if it contains 0 streams (the streams array/collection would be empty).
