### PR TITLE
Address next button redirect issue.

### DIFF
--- a/twitchery.js
+++ b/twitchery.js
@@ -84,9 +84,10 @@ document.addEventListener("DOMContentLoaded", function(){
 			var totalPageCount = document.getElementById("total-num-pages")
 			var indexOfLimitParam = queryResults["_links"]["self"].indexOf("limit")
 			var requestLimit = queryResults["_links"]["self"].substring(indexOfLimitParam + 6, indexOfLimitParam + 8)
-			totalPageCount.innerText = Math.ceil(queryResults["_total"] / requestLimit)
+			var totalNumOfPages = Math.ceil(queryResults["_total"] / requestLimit)
+			totalPageCount.innerText = totalNumOfPages
 
-			if(queryResults["_links"]["next"]){
+			if(queryResults["_links"]["next"] && resultPageNumber !== totalNumOfPages){
 				var nextPageLink = document.getElementsByClassName("next-link")[0]
 				nextPageLink.setAttribute("href", queryResults["_links"]["next"])
 				nextPageLink.addEventListener('click', navigateToPage)


### PR DESCRIPTION
The next button would hit one of the API routes even when a user was looking at the last page of results from their search. As mentioned in an earlier commit, the XHR response still provides a 'next link', but upon redirecting to that next link, there would be no stream objects to render. The current fix checks to see if the user is on the last page, and if so, prevents the user from being redirected. Next step is to toggle the visibility of the previous and next buttons based on more conditional logic.
