### PR TITLE
Toggle display of pagination buttons.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
 
 <div id="search-results" class="debug">
 	<div class="nav">
-		<p id="results-message">Total results: <span id="results-count"></span></p>
+		<p id="results-message" class="displ-none">Total results: <span id="results-count"></span></p>
 		<div id="pagination-links">
-			<a href="#" class="previous-link"><button>Previous</button></a>
+			<a href="#" class="previous-link displ-none"><button>Previous</button></a>
 			<p id="page-index"><span id="current-page-number">1</span> / <span id="total-num-pages">1</span></p>
-			<a href="#" class="next-link"><button>Next</button></a>
+			<a href="#" class="next-link displ-none"><button>Next</button></a>
 		</div>
 	</div>
 	

--- a/twitchery.css
+++ b/twitchery.css
@@ -21,9 +21,13 @@ html, body{
 	padding-left: 10%;
 }
 
+.displ-none{
+	display:none;
+}
+/*
 #results-message{
 	display: none;
-}
+}*/
 
 #pagination-links{
 	float: right;

--- a/twitchery.js
+++ b/twitchery.js
@@ -10,6 +10,11 @@ document.addEventListener("DOMContentLoaded", function(){
 	var searchResultsList = document.getElementById('search-results-list')
 	var resultsCountText = document.getElementById('results-count')
 
+	var currentPageNumber = document.getElementById("current-page-number")
+	var totalPageCount = document.getElementById("total-num-pages")
+	var nextPageLink = document.getElementsByClassName("next-link")[0]
+	var previousPageLink = document.getElementsByClassName("previous-link")[0]
+
 	function returnSearchResults(event){
 		event.preventDefault()
 		resultsMessage.style.visibility = 'visible'
@@ -71,29 +76,26 @@ document.addEventListener("DOMContentLoaded", function(){
 	}
 
 	function handlePagination(queryResults){
+		hidePreviousLinkButton()
+		hideNextLinkButton()
 		if(queryResults["_total"] > 10){
-			//denominator in the current page/ total pages
-			// console.log("generate " + Math.ceil(queryResults["_total"] / 10) + " pages")
-			var currentPageNumber = document.getElementById("current-page-number")
 			var indexOfResultPageNumber = queryResults["_links"]["self"].indexOf("offset")
 
-			//identified bug - the api still provides a next link even if there are no streams returned from the next link
 			var resultPageNumber = parseInt(queryResults["_links"]["self"].substring(indexOfResultPageNumber + 7, indexOfResultPageNumber + 8)) + 1
 			currentPageNumber.innerText = resultPageNumber
 
-			var totalPageCount = document.getElementById("total-num-pages")
 			var indexOfLimitParam = queryResults["_links"]["self"].indexOf("limit")
 			var requestLimit = queryResults["_links"]["self"].substring(indexOfLimitParam + 6, indexOfLimitParam + 8)
 			var totalNumOfPages = Math.ceil(queryResults["_total"] / requestLimit)
 			totalPageCount.innerText = totalNumOfPages
 
 			if(queryResults["_links"]["next"] && resultPageNumber !== totalNumOfPages){
-				var nextPageLink = document.getElementsByClassName("next-link")[0]
+				showNextLinkButton()
 				nextPageLink.setAttribute("href", queryResults["_links"]["next"])
 				nextPageLink.addEventListener('click', navigateToPage)
 			}
 			if(queryResults["_links"]["prev"]){
-				var previousPageLink = document.getElementsByClassName("previous-link")[0]
+				showPreviousLinkButton()
 				previousPageLink.setAttribute("href", queryResults["_links"]["prev"])
 				previousPageLink.addEventListener('click', navigateToPage)
 			}
@@ -131,6 +133,23 @@ document.addEventListener("DOMContentLoaded", function(){
 		streamDescription.innerText = channelName + " playing " + gameName
 		return streamDescription
 	}
+
+	function showPreviousLinkButton(){
+		previousPageLink.style.display = "inline"
+	}
+
+	function hidePreviousLinkButton(){
+		previousPageLink.style.display = "none"
+	}
+
+	function showNextLinkButton(){
+		nextPageLink.style.display = "inline"
+	}
+
+	function hideNextLinkButton(){
+		nextPageLink.style.display = "none"
+	}
+
 
 	function showResultsCount(){
 		resultsMessage.style.display = "inline"


### PR DESCRIPTION
Added a displ-none class to the pagination buttons and the results message elements so that when the user first loads the page, the user does not see them since no search has been made yet. Based on whether or not the route hit contains a previous and/or next link, their respective buttons will be toggled to be visible. Considered simple using JavaScript's classList.toggle() approach, but that seemed less efficient when I had to consider what the classList state of the buttons were after each page redirection. Chose to go with manipulating the style rather than toggling classes and writing more lines of code.
