### PR TITLE
Finish initial implementation of tooltips.

### DIFF
--- a/twitchery.css
+++ b/twitchery.css
@@ -41,6 +41,10 @@ input[type=submit]:hover
 	cursor: pointer;
 }
 
+.bg-white{
+	background-color: #ffffff;
+}
+
 .block{
 	display: block;
 }
@@ -50,13 +54,24 @@ input[type=submit]:hover
 	font-weight: 600;
 }
 
+.cntr-txt
+{
+	text-align: center;
+}
+
 .displ-none
 {
 	display: none;
 }
 
-.fl-right{
+.fl-right
+{
 	float:right;
+}
+
+.img-border
+{
+	border: 3px groove #6441A5
 }
 
 .info-box
@@ -123,6 +138,11 @@ input[type=submit].active
 	margin-top: 60px;
 }
 
+.pad-10p
+{
+	padding: 10px 10px;
+}
+
 .pad-right-40p
 {
 	padding-right: 40px;
@@ -140,15 +160,48 @@ input[type=submit].active
 	position: absolute;
 }
 
+
+.pos-left-0
+{
+	left: 0;
+}
+
+.pos-rel
+{
+	position: relative;
+}
+
+.pos-top-0
+{
+	top: 0;
+}
+
 .row
 {
 	padding-top: 20px;
 	padding-bottom: 20px;
-	border-bottom: 1px solid #6441a5;
+	border-bottom: 2px solid #6441A5;
 }
 
-.stream-description:hover{
+.stream-description
+{
+	color: #420dbf;
+}
+
+.stream-description:hover
+{
 	color: #6441a5;
+}
+
+.tooltip{
+	height: 200px;
+	width: 200px;
+	border: 3px groove #6441A5;
+	z-index: 1;
+}
+
+.tooltip:hover{
+	cursor: pointer;
 }
 
 .twitch-color{

--- a/twitchery.js
+++ b/twitchery.js
@@ -153,7 +153,7 @@ document.addEventListener("DOMContentLoaded", function(){
 	function createThumbnailImage(streamObject){
 		var thumbnailUrl = streamObject["preview"]["medium"];
 		var thumbnailImage = new Image("180", "180");
-		thumbnailImage.classList.add("thumbnail-img", "inline-b");
+		thumbnailImage.classList.add("thumbnail-img", "inline-b", "img-border");
 		thumbnailImage.src = thumbnailUrl;
 		return thumbnailImage;
 	}
@@ -212,29 +212,38 @@ document.addEventListener("DOMContentLoaded", function(){
 
 	function addTooltip(streamObject){
 		var tooltip = document.createElement('span')
-		tooltip.style.position = 'absolute'
-		tooltip.style.top = '0'
-		tooltip.style.left = '0'
-		tooltip.style.height = '200px'
-		tooltip.style.width = '200px'
 		tooltip.innerText = streamObject["channel"]["display_name"]
-		tooltip.style.zIndex = '1'
-		tooltip.style.display = 'none'
+		tooltip.classList.add("tooltip","pad-10p", "pos-rel", "pos-top-0", "pos-left-0", "cntr-txt", "displ-none", "bg-white")
 
 		var channelLogo = new Image("150", "150")
+		channelLogo.classList.add("block", "mrg-0-auto", "img-border")
 		channelLogo.src = streamObject["channel"]["logo"]
-
 		tooltip.appendChild(channelLogo)
+		tooltip.addEventListener("click", goToChannelProfile)
 		return tooltip
 	}
 
 	function showTooltip(){
-		// console.log(this.children[0])
-		// this.children[0].s
 		toggleDisplay(this.children[0], "block")
+		tintBackground()
 	}
 
 	function hideTooltip(){
 		toggleDisplay(this.children[0], "none")
+		untintBackground()
+	}
+
+	function tintBackground(){
+		document.body.style.backgroundColor = "#fbf7ff"
+		document.body.style.opacity = ".9"
+	}
+
+	function untintBackground(){
+		document.body.style.backgroundColor = "#FFFFFF"
+		document.body.style.opacity = "1"
+	}
+
+	function goToChannelProfile(){
+		window.open(twitchUrl + this.innerText + "/profile")
 	}
 })


### PR DESCRIPTION
Upon stream description hover event, page renders a tooltip containing the respective channel name and channel logo. The tooltip is clickable, and upon clicking one, the user's window will open a new tab that links to the actual channel on Twitch. The page also becomes tinted when a tooltip is active, and returns to normal once the user moves their mouse away from the tooltip and stream description. Something to think about is whether or not the tooltip is intuitive, as it may worsen a user's experience given that the user may have to go out of their way to move their mouse to continue navigating the page.
