### PR TITLE
Add stream video link redirect.

### DIFF
--- a/twitchery.css
+++ b/twitchery.css
@@ -193,6 +193,10 @@ input[type=submit].active
 	color: #6441a5;
 }
 
+.thumbnail-img:hover{
+	cursor: pointer;
+}
+
 .tooltip{
 	height: 200px;
 	width: 200px;

--- a/twitchery.js
+++ b/twitchery.js
@@ -155,6 +155,7 @@ document.addEventListener("DOMContentLoaded", function(){
 		var thumbnailImage = new Image("180", "180");
 		thumbnailImage.classList.add("thumbnail-img", "inline-b", "img-border");
 		thumbnailImage.src = thumbnailUrl;
+		thumbnailImage.addEventListener("click", goToStreamPage)
 		return thumbnailImage;
 	}
 
@@ -245,5 +246,10 @@ document.addEventListener("DOMContentLoaded", function(){
 
 	function goToChannelProfile(){
 		window.open(twitchUrl + this.innerText + "/profile");
+	}
+
+	function goToStreamPage(){
+		var streamUrl = this.nextSibling.children[0].children[0].attributes["href"]["value"]
+		window.open(streamUrl)
 	}
 })


### PR DESCRIPTION
Added event listener for click event on thumbnail preview images of streams that open a new tab to the actual stream on the Twitch site. Noticed this error: 'GET file:///Users/harveyngo/Desktop/code/interview-challenges/Twitchery/null net::ERR_FILE_NOT_FOUND' that occurs after making a proper search request, but unsure what is causing it at the moment.
