### PR TITLE
Change link to live demo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Twitchery is a single page web app that allows you to search for Twitch streams!
 
 It's witchcraft with Twitch's craft..! Yet for some reason, I named it with the word sorcery in mind..
 
-Check it out live [here](http://htmlpreview.github.io/?https://github.com/hdngo/Twitchery/blob/master/index.html).
+Check it out live on Heroku [here](http://twitchery.herokuapp.com/).
 
 ##UPDATE
 New Features Implemented


### PR DESCRIPTION
Changed README's link to the live demo to redirect to the url for the Heroku hosted version.
